### PR TITLE
BUGFIX: Correct order of is_last and is_command

### DIFF
--- a/include/wolfpacs_types.hrl
+++ b/include/wolfpacs_types.hrl
@@ -1,4 +1,4 @@
 -type decoded() :: {ok, binary(), binary()} | {error, binary()}.
 -type decoded_list() :: {ok, list(binary()), binary()} | {error, binary()}.
 
--record(pdv_item, {pr_cid, is_command, is_last, pdv_data}).
+-record(pdv_item, {pr_cid, is_last, is_command, pdv_data}).

--- a/src/wolfpacs_pdv_item.erl
+++ b/src/wolfpacs_pdv_item.erl
@@ -19,11 +19,11 @@
 -spec encode(#pdv_item{}) -> binary().
 encode(PDVItem) ->
     #pdv_item{pr_cid=PrCID,
-	      is_command=IsCommand,
 	      is_last=IsLast,
+	      is_command=IsCommand,
 	      pdv_data=PDVData} = PDVItem,
-    Fragment = wolfpacs_pdv_item_fragement:encode(IsCommand,
-						  IsLast,
+    Fragment = wolfpacs_pdv_item_fragement:encode(IsLast,
+						  IsCommand,
 						  PDVData),
     Data = <<PrCID, Fragment/binary>>,
     NbBytes = byte_size(Data),
@@ -40,10 +40,10 @@ decode(AllData = <<Length:32, Data/binary>>) ->
     case wolfpacs_utils:split(Data, Length) of
 	{ok, <<PrCID, FragmentData/binary>>, Rest} ->
 	    case wolfpacs_pdv_item_fragement:decode(FragmentData) of
-		{ok, IsCommand, IsLast, PDVData} ->
+		{ok, IsLast, IsCommand, PDVData} ->
 		    PDVItem = #pdv_item{pr_cid=PrCID,
-					is_command=IsCommand,
 					is_last=IsLast,
+					is_command=IsCommand,
 					pdv_data=PDVData},
 		    {ok, PDVItem, Rest};
 		_ ->
@@ -62,8 +62,8 @@ decode(AllData = <<Length:32, Data/binary>>) ->
 encode_decode_test_() ->
     PDVData = <<1, 2, 3, 4, 5>>,
     PDVItem = #pdv_item{pr_cid=42,
-			is_command=true,
 			is_last=false,
+			is_command=true,
 			pdv_data=PDVData},
     Rest = <<42, 44>>,
 

--- a/src/wolfpacs_pdv_item_fragement.erl
+++ b/src/wolfpacs_pdv_item_fragement.erl
@@ -1,7 +1,16 @@
 %%%-------------------------------------------------------------------
 %% @doc WolfPACS's Protocol Data Value (PDV) Framgment Item
 %%
-%% Ref: pg 200
+%% If bit 0 is set to 1, the following fragment shall contain Message Command information.
+%% If bit 0 is set to 0, the following fragment shall contain Message Data Set information.
+%%
+%% If bit 1 is set to 1, the following fragment shall contain the last fragment.
+%% If bit 1 is set to 0, the following fragment does not contain the last fragment.
+%%
+%% 0 0 0 0 0 0 L? C?
+%%
+%% [http://dicom.nema.org/dicom/2013/output/chtml/part08/sect_E.2.html]
+%% DICOM book pg 200
 %%
 %% @end
 %%%-------------------------------------------------------------------
@@ -15,7 +24,7 @@
 %%
 %% @end
 %%-------------------------------------------------------------------
--spec encode(IsCommand :: boolean(), IsLast :: boolean(), PDVData :: binary()) -> binary().
+-spec encode(IsLast :: boolean(), IsCommand :: boolean(), DVData :: binary()) -> binary().
 encode(false, false, Data) ->
     <<0:6, 0:1, 0:1, Data/binary>>;
 encode(false, true, Data) ->
@@ -30,7 +39,7 @@ encode(true, true, Data) ->
 %%
 %% @end
 %%-------------------------------------------------------------------
--spec decode(binary()) -> {ok, IsCommand :: boolean(), IsLast :: boolean(), PDVData :: binary()} | {error, binary()}.
+-spec decode(binary()) -> {ok, IsLast :: boolean(), IsCommand :: boolean(), PDVData :: binary()} | {error, binary()}.
 decode(<<0:6, B1:1, B0:1, Data/binary>>) ->
     {ok, B1==1, B0==1, Data};
 decode(Data) ->


### PR DESCRIPTION
There was in the bug in pdv_item_fragment. Previously,
I had reversed the order of the bits in the header.