### PR TITLE
Add support for pausing and unpausing a worker.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Docker build](https://img.shields.io/docker/cloud/build/wolfpacs/wolfpacs.svg?color=green)](https://hub.docker.com/r/wolfpacs/wolfpacs)
 [![License Apache 2](https://img.shields.io/badge/License-Apache2-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 [![Documentation](https://img.shields.io/badge/documentation-documentation-yellowgreen)](https://wolfpacs.github.io/wolfpacs/)
-[![Version Observance](https://img.shields.io/badge/semver-0.3.3-blue)](https://semver.org/)
+[![Version Observance](https://img.shields.io/badge/semver-0.3.4-blue)](https://semver.org/)
 
 ![Logo](priv/logo.png)
 


### PR DESCRIPTION
    It is sometimes important to take a worker offline in
    controlled manner. Therefore, add support to pause a worker.
    That way, the worker will continue to receive series for all
    mapped studies, but not receive any new studies.
    
    Once all the studies that are mapped are finished (which might take
    many minutes), the worker is safe to take offline. When the worker
    is ready for new jobs again - just simply unpause it.